### PR TITLE
helm: add k3d local deployment; integrate secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@ Run rubocop or tests:
 1. Run application `SLACK_API_TOKEN=<test-token> bundle exec puma`
 
 ## Kubernetes Deploy
-1. A working kubernetes cluster: `minikube start`
-1. An install of helm and kubectl
-1. Tiller in the cluster: `helm init`
-1. A secret.yaml installed on the cluster like `theodor/secret.yaml` with your
-   API token base64-encoded
-1. Install secret: `kubectl create -f theodor/secret.yaml`
+Install Dependencies:
+  - [k3d][k3d] (allows running a [k3s][k3s] cluster locally inside Docker containers)
+  - Docker, Helm, and kubectl (other required dependencies)
 
-1. Dry Run/Debugging: `helm install --dry-run --debug ./theodor`
-1. Real Deal Run: `helm install --name theodor ./theodor`
+1. Run the `./k3d-theodor.sh <api-token>` script, ensuring to pass the test API token as a
+   parameter
+1. You can navigate to the `bot-testing` channel to interact w/ the
+   `theodor-test` bot instance, or directly via DM
+
+[k3d]:https://github.com/rancher/k3d/
+[k3s]:https://github.com/rancher/k3s/

--- a/k3d-theodor.sh
+++ b/k3d-theodor.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+
+if test $# -ne 1 ; then
+  echo "You must provide the Slack API token for the bot to connect to"
+  exit 1
+fi
+api_token=$1
+
+echo "cluster: creating theodor k3s cluster"
+k3d create -n theodor --workers 1
+echo "sleeping for a bit to let the cluster spin up"
+sleep 15
+echo "k3s: setting up kubeconfig"
+export KUBECONFIG="$(k3d get-kubeconfig --name='theodor')"
+
+echo "tiller: creating service account"
+kubectl -n kube-system create serviceaccount tiller
+echo "tiller: setting up rbac for service account"
+kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
+
+echo "helm: initializing with tiller service account"
+helm init --service-account tiller
+
+echo "wait while tiller installs"
+sleep 60
+
+echo "helm: installing Theodor"
+helm install --name theodor ./theodor --set=apiToken="$api_token"
+
+

--- a/theodor/secret.yaml
+++ b/theodor/secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: slack-secret
-type: Opaque
-data:
-  slack_api_token: base64-encoded-api-token-here-please

--- a/theodor/templates/deployment.yaml
+++ b/theodor/templates/deployment.yaml
@@ -25,11 +25,11 @@ spec:
           command: ['bundle', 'exec', 'puma']
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: {{ .Values.image.env.name }}
+            - name: "SLACK_API_TOKEN"
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.image.env.secretKeyRefName }}
-                  key: {{ .Values.image.env.secretKeyRefKey }}
+                  name: {{ template "theodor.fullname" . }}
+                  key: slack_api_token
           ports:
             - name: http
               containerPort: 80

--- a/theodor/templates/secrets.yaml
+++ b/theodor/templates/secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "theodor.fullname" . }}
+  labels:
+    app: {{ template "theodor.name" . }}
+    chart: {{ template "theodor.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  slack_api_token: {{ .Values.apiToken | b64enc | quote }}

--- a/theodor/values.yaml
+++ b/theodor/values.yaml
@@ -8,10 +8,9 @@ image:
   repository: ucsdlib/theodor
   tag: production
   pullPolicy: IfNotPresent
-  env:
-    name: SLACK_API_TOKEN
-    secretKeyRefName: slack-secret
-    secretKeyRefKey: slack_api_token
+
+# Slack API token
+apiToken: a-token
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Changes:
- Add `k3d-theodor.sh` script for provisioning a `k3s` cluster locally for
  development
- Document using the `k3d-theodor.sh` script in the `README`
- Rename the `secret.yaml` file to `secrets.yaml` and move to the `charts/templates` directory so it is setup as a proper Helm template file
- Use `apiToken` as the value to pass into the Helm chart for generating a secret to populate the `SLACK_API_TOKEN` environment variable

Related to: #111 

@VivianChu @rstanonik - please review